### PR TITLE
Improve token refresh resiliency

### DIFF
--- a/.github/workflows/master_comcastbusinessauthentication.yml
+++ b/.github/workflows/master_comcastbusinessauthentication.yml
@@ -2,14 +2,15 @@
 
 name: Comcast Business Authentication
 
-# ── Trigger either manually or on a cron schedule every 55 minutes ──
+# ── Trigger either manually or on a cron schedule every 45 minutes ──
 on:
   workflow_dispatch:
   schedule:
-    - cron: "*/55 * * * *"     # every 55 minutes; adjust as needed
+    - cron: "*/45 * * * *"     # every 45 minutes; adjust as needed
 
 jobs:
   headed-playwright:
+    concurrency: comcast-auth
     runs-on: ubuntu-latest
     timeout-minutes: 15       # timeout if Comcast hangs
 

--- a/Program.cs
+++ b/Program.cs
@@ -21,10 +21,10 @@ class Program
         Console.WriteLine(">>> Fetched fresh tokens:");
         Console.WriteLine(json);
 
-        // 3. Store in Redis with a suitable TTL (e.g. 15 minutes)
-        //    Adjust the TTL based on how long these tokens remain valid in BusinessVoice.
-        var ttl = TimeSpan.FromMinutes(55);
-        await RedisHelper.SetStringAsync(CacheKey, json, ttl);
+        // 3. Store in Redis only after a successful fetch
+        var ttl = TimeSpan.FromMinutes(58);
+        await RedisHelper.SetStringAsync(CacheKey, json);
+        await RedisHelper.KeyExpireAsync(CacheKey, ttl);
 
         Console.WriteLine($">>> Tokens cached under '{CacheKey}' for {ttl.TotalMinutes} minutes.");
     }

--- a/TokenFetcher.cs
+++ b/TokenFetcher.cs
@@ -23,7 +23,21 @@ public sealed class TokenFetcher
         ]
     };
 
-    public static async Task<string> GetTokensAsync()
+    public static async Task<string> GetTokensAsync(int attempts = 3)
+    {
+        for (var i = 1; i <= attempts; i++)
+        {
+            try { return await DoFetchAsync(); }
+            catch when (i < attempts)
+            {
+                Console.WriteLine($"Fetch failed (try {i}) – retrying in 10 s");
+                await Task.Delay(TimeSpan.FromSeconds(10));
+            }
+        }
+        throw new Exception($"Playwright failed after {attempts} attempts");
+    }
+
+    private static async Task<string> DoFetchAsync()
     {
         using var playwright = await Playwright.CreateAsync();
         var browser = await playwright.Chromium.LaunchAsync(browserTypeLaunchOptions);

--- a/Utilities/RedisHelper.cs
+++ b/Utilities/RedisHelper.cs
@@ -28,11 +28,19 @@ namespace Comcast_Business_Authentication.Utilities
         }
 
         /// <summary>
-        /// Sets a string value with an expiration TTL.
+        /// Sets a string value without altering the TTL.
         /// </summary>
-        public static async Task SetStringAsync(string key, string value, TimeSpan ttl)
+        public static async Task SetStringAsync(string key, string value)
         {
-            await Database.StringSetAsync(key, value, ttl);
+            await Database.StringSetAsync(key, value);
+        }
+
+        /// <summary>
+        /// Updates the expiration time for a cached key.
+        /// </summary>
+        public static async Task KeyExpireAsync(string key, TimeSpan ttl)
+        {
+            await Database.KeyExpireAsync(key, ttl);
         }
     }
 }


### PR DESCRIPTION
## Summary
- buffer GitHub Action cron schedule and avoid overlaps
- split Redis helpers so TTL is set safely
- retry token fetches before failing
- update TTL configuration in Program

## Testing
- `dotnet build --configuration Release --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f78b7c514832ea9a448010aebea4d